### PR TITLE
Documentation and API Changes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,28 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/documentation.yml
+      - Sources/**.swift
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Generate Documentation
+        uses: SwiftDocOrg/swift-doc@master
+        with:
+          inputs: "Sources"
+          output: "Documentation"
+      - name: Upload Documentation to Wiki
+        uses: SwiftDocOrg/github-wiki-publish-action@master
+        with:
+          path: "Documentation"
+        env:
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "53741ba55ecca5c7149d8c9f810913ec80845c69",
+          "version": "3.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-         .package(url: "https://github.com/jpsim/Yams.git", from: "2.0.0"),
+        .package(url: "https://github.com/jpsim/Yams.git", "2.0.0"..<"4.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/TAP/BailOut.swift
+++ b/Sources/TAP/BailOut.swift
@@ -1,0 +1,24 @@
+/**
+ An error that can be thrown from a test to stop the execution of further tests.
+
+ From the [TAP specification](https://testanything.org/tap-specification.html):
+
+ > ### Bail out!
+ >
+ > As an emergency measure
+ > a test script can decide that further tests are useless
+ > (e.g. missing dependencies)
+ > and testing should stop immediately.
+ > In that case the test script prints the magic words `Bail out!`
+ > to standard output.
+ > Any message after these words must be displayed by the interpreter
+ > as the reason why testing must be stopped,
+ > as in `Bail out! MySQL is not running.`
+ */
+public struct BailOut: Error, LosslessStringConvertible {
+    public let description: String
+
+    public init(_ description: String = "") {
+        self.description = description
+    }
+}

--- a/Sources/TAP/Directive.swift
+++ b/Sources/TAP/Directive.swift
@@ -1,5 +1,58 @@
+/**
+ An error that can be thrown from a test to reinterpret its outcome.
+
+ From the [TAP specification](https://testanything.org/tap-specification.html):
+
+ > Directives are special notes that follow a # on the test line.
+ > Only two are currently defined: `TODO` and `SKIP`.
+ > Note that these two keywords are not case-sensitive.
+ */
 public enum Directive: Error {
+    /**
+     Indicates that a test isn't expected to pass.
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > TODO tests
+     >
+     > If the directive starts with `# TODO`,
+     > the test is counted as a todo test,
+     > and the text after `TODO` is the explanation.
+     >
+     > `not ok 13 # TODO bend space and time`
+     >
+     > Note that if the `TODO` has an explanation
+     > it must be separated from `TODO` by a space.
+     > These tests represent a feature to be implemented or a bug to be fixed
+     > and act as something of an executable “things to do” list.
+     > They are not expected to succeed.
+     > Should a todo test point begin succeeding,
+     > the harness should report it as a bonus.
+     > This indicates that whatever you were supposed to do has been done
+     > and you should promote this to a normal test point.
+     */
     case todo(explanation: String? = nil)
+
+    /**
+     Indicates that a test should be skipped.
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > ### Skipping tests
+     >
+     > If the directive starts with `# SKIP`,
+     > the test is counted as having been skipped.
+     > If the whole test file succeeds,
+     > the count of skipped tests is included in the generated output.
+     > The harness should report the text after `# SKIP\S*\s+`
+     > as a reason for skipping.
+     >
+     > `ok 23 # skip Insufficient flogiston pressure.`
+     >
+     > Similarly, one can include an explanation in a plan line,
+     > emitted if the test file is skipped completely:
+     >
+     > `1..0 # Skipped: WWW::Mechanize not installed`
+     */
     case skip(explanation: String? = nil)
-    case bailOut(explanation: String? = nil)
 }

--- a/Sources/TAP/TAP.swift
+++ b/Sources/TAP/TAP.swift
@@ -1,3 +1,9 @@
-public func TAP(explanation: String? = nil, _ tests: [Test]) {
-    print(tests.run())
+/**
+ Runs the specified tests and prints the results in TAP format.
+
+ - Parameter tests: The tests to run.
+ - Throws: If any tests throw an error that isn't `BailOut` or `Directive`.
+ */
+public func TAP(_ tests: [Test]) throws {
+    print(try tests.run())
 }

--- a/Sources/TAP/Test.swift
+++ b/Sources/TAP/Test.swift
@@ -1,22 +1,158 @@
-public typealias Test = () -> Outcome
+/**
+ A test that produces an outcome.
 
+ Throw a `Directive` to indicate how a test should be interpreted,
+ or throw `BailOut` to stop the execution of further tests.
+ */
+public typealias Test = () throws -> Outcome
+
+/**
+ The outcome of running a test.
+ */
 public struct Outcome {
+    /**
+     Whether the test passed or failed.
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > #### • ok or not ok
+     >
+     > This tells whether the test point passed or failed.
+     > It must be at the beginning of the line.
+     > `/^not ok/` indicates a failed test point.
+     > `/^ok/` is a successful test point.
+     > This is the only mandatory part of the line.
+     > Note that unlike the Directives below,
+     > ok and not ok are case-sensitive.
+     */
     public let ok: Bool
+
+    /**
+     A description of the tested behavior.
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > #### • Description
+     >
+     > Any text after the test number but before a `#`
+     > is the description of the test point.
+     >
+     > `ok 42 this is the description of the test`
+     >
+     > Descriptions should not begin with a digit
+     > so that they are not confused with the test point number.
+     > The harness may do whatever it wants with the description.
+     */
     public let description: String?
+
+    /**
+     A directive for how to interpret a test outcome.
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > #### • Directive
+     >
+     > The test point may include a directive,
+     > following a hash on the test line.
+     > There are currently two directives allowed:
+     > `TODO` and `SKIP`.
+     */
     public let directive: Directive?
+
+    /**
+     Additional information about a test,
+     such as its source location (file / line / column)
+     or the actual and expected results.
+
+     Test outcome metadata is encoded as [YAML](https://yaml.org).
+
+     From the [TAP v13 specification](https://testanything.org/tap-version-13-specification.html):
+
+     > ### YAML blocks
+     >
+     > If the test line is immediately followed by
+     > an indented block beginning with `/^\s+---/` and ending with `/^\s+.../`
+     > that block will be interpreted as an inline YAML document.
+     > The YAML encodes a data structure that provides
+     > more detailed information about the preceding test.
+     > The YAML document is indented to make it
+     > visually distinct from the surrounding test results
+     > and to make it easier for the parser to recover
+     > if the trailing ‘…’ terminator is missing.
+     > For example:
+     >
+     >   not ok 3 Resolve address
+     >   ---
+     >   message: "Failed with error 'hostname peebles.example.com not found'"
+     >   severity: fail
+     >   data:
+     >   got:
+     >       hostname: 'peebles.example.com'
+     >       address: ~
+     >   expected:
+     >       hostname: 'peebles.example.com'
+     >       address: '85.193.201.85'
+     >   ...
+     */
     public let metadata: [String: Any]?
 
-    public static func success(_ description: String? = nil, directive: Directive? = nil, metadata: [String: Any]? = nil) -> Outcome {
+    /**
+     Creates a successful test outcome.
+
+     - Parameters:
+        - description: A description of the tested behavior.
+                       `nil` by default.
+        - directive: A directive for how to interpret a test outcome.
+                     `nil` by default.
+        - metadata: Additional information about a test.
+                    `nil` by default.
+     - Returns: A successful test outcome.
+     */
+    public static func success(_ description: String? = nil,
+                               directive: Directive? = nil,
+                               metadata: [String: Any]? = nil) -> Outcome
+    {
         return Outcome(ok: true, description: description, directive: directive, metadata: metadata)
     }
 
-    public static func failure(_ description: String? = nil, directive: Directive? = nil, metadata: [String: Any]? = nil) -> Outcome {
+    /**
+     Creates an unsuccessful test outcome.
+
+     - Parameters:
+        - description: A description of the tested behavior.
+                       `nil` by default.
+        - directive: A directive for how to interpret a test outcome.
+                     `nil` by default.
+        - metadata: Additional information about a test.
+                    `nil` by default.
+     - Returns: An unsuccessful test outcome.
+    */
+    public static func failure(_ description: String? = nil,
+                               directive: Directive? = nil,
+                               metadata: [String: Any]? = nil) -> Outcome
+    {
         return Outcome(ok: false, description: description, directive: directive, metadata: metadata)
     }
 }
 
 // MARK: -
 
+/**
+ Creates a test from an expression that returns a Boolean value.
+
+ - Parameters:
+    - body: A closure containing the tested behavior,
+            Return `true` to indicate successful execution
+            or `false to indicate test failure.
+            Throw a `Directive` to indicate how a test should be interpreted,
+            or throw `BailOut` to stop the execution of further tests.
+    - description: A description of the tested behavior.
+                   `nil` by default.
+    - file: The source code file in which this test occurs.
+    - line: The line in source code on which this test occurs.
+    - column: The column in source code at which this test occurs.
+ - Returns: A test.
+ */
 public func test(_ body: @escaping @autoclosure () throws -> Bool,
                  _ description: String? = nil,
                  file: String = #file,
@@ -25,6 +161,22 @@ public func test(_ body: @escaping @autoclosure () throws -> Bool,
     return test(body, description, file: file, line: line, column: column)
 }
 
+/**
+ Creates a test from a closure that returns a Boolean value.
+
+ - Parameters:
+    - body: A closure containing the tested behavior,
+            Return `true` to indicate successful execution
+            or `false to indicate test failure.
+            Throw a `Directive` to indicate how a test should be interpreted,
+            or throw `BailOut` to stop the execution of further tests.
+    - description: A description of the tested behavior.
+                   `nil` by default.
+    - file: The source code file in which this test occurs.
+    - line: The line in source code on which this test occurs.
+    - column: The column in source code at which this test occurs.
+ - Returns: A test.
+*/
 public func test(_ body: @escaping () throws -> Bool,
                  _ description: String? = nil,
                  file: String = #file,
@@ -45,17 +197,26 @@ public func test(_ body: @escaping () throws -> Bool,
                 }
             } catch let directive as Directive {
                 switch directive {
-                case .bailOut:
+                case .todo:
                     return .failure(description, directive: directive, metadata: metadata)
-                default:
+                case .skip:
                     return .success(description, directive: directive, metadata: nil)
                 }
+            } catch let bailOut as BailOut {
+                throw bailOut
             } catch {
                 return .failure(description ?? "\(error)", directive: nil, metadata: metadata)
             }
         }
 }
 
+/**
+ Creates a test from a closure that produces an outcome.
+
+ - Parameters:
+    - body: A closure that produces an outcome for some tested behavior.
+ - Returns: A test.
+*/
 public func test(_ body: @escaping () -> Outcome) -> Test {
     return { body() }
 }
@@ -63,7 +224,24 @@ public func test(_ body: @escaping () -> Outcome) -> Test {
 // MARK: -
 
 extension Array where Element == Test {
-    public func run() -> Report {
-        return Report(map { $0() })
+    /**
+     Runs the contained tests in order
+     and produces a report summarizing the results.
+
+     - Returns: A report summarizing the test results.
+     */
+    public func run() throws -> Report {
+        let results = try map { test -> Result<Outcome, BailOut> in
+            do {
+                let outcome = try test()
+                return .success(outcome)
+            } catch let bailOut as BailOut {
+                return .failure(bailOut)
+            } catch {
+                throw error
+            }
+        }
+
+        return Report(results: results)
     }
 }

--- a/Tests/TAPTests/TAPTests.swift
+++ b/Tests/TAPTests/TAPTests.swift
@@ -2,19 +2,19 @@ import XCTest
 import TAP
 
 final class TAPTests: XCTestCase {
-    func testExample() {
-        let report = Report(explanation: "Run tests", [
+    func testExample() throws {
+        let report = try [
             test(true),
             test(false),
             test({ throw Directive.skip(explanation: "unnecessary") }),
             test({ throw Directive.todo(explanation: "unimplemented") }),
-            test({ throw Directive.bailOut(explanation: "😱") })
-        ].map { $0() })
+            test({ throw BailOut("😱") }),
+            test(true)
+        ].run()
 
         let expected = """
         TAP version 13
-        1..5
-        # Run tests
+        1..6
         ok 1
         not ok 2
           ---
@@ -24,7 +24,13 @@ final class TAPTests: XCTestCase {
           ...
           \("" /* keep indentation level for blank line */)
         ok 3 # SKIP unnecessary
-        ok 4 # TODO unimplemented
+        not ok 4 # TODO unimplemented
+          ---
+          column: 17
+          file: \(#file)
+          line: 10
+          ...
+          \("" /* keep indentation level for blank line */)
         Bail out! 😱
         """
 
@@ -33,8 +39,8 @@ final class TAPTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
 
-    func testUsage() {
-        TAP([
+    func testUsage() throws {
+        try TAP([
             test(true)
         ])
     }


### PR DESCRIPTION
In the process of documenting the API, I noticed a few inconsistencies with the TAP v13 API, and adjusted accordingly. Notably:

- `Report` no longer has an `explanation` property, which manifested itself as a "diagnostic" in the test report. I don't see a great way to support arbitrary inline diagnostics without upending the whole design, so I decided not to support diagnostics at all.
- `BailOut` is now its own structure rather than a `Diagnostic` case. To make that work, I needed to redefine `Test` to be `throws`; as a result the top-level `TAP` convenience method and the constrained Array extension method are `throws`, too. (This wouldn't be necessary if Swift offered some way to type `throws` declarations. The only error that can bubble up from a test is `BailOut`; anything else is a test failure.)